### PR TITLE
fix(wishlists): proper behavior for wishlist 

### DIFF
--- a/src/Context/WishlistContextInterface.php
+++ b/src/Context/WishlistContextInterface.php
@@ -11,9 +11,8 @@ declare(strict_types=1);
 namespace BitBag\SyliusWishlistPlugin\Context;
 
 use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 interface WishlistContextInterface
 {
-    public function getWishlist(Request $request): ?WishlistInterface;
+    public function getWishlist(): ?WishlistInterface;
 }

--- a/src/Controller/Action/ListWishlistProductsAction.php
+++ b/src/Controller/Action/ListWishlistProductsAction.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusWishlistPlugin\Controller\Action;
 
+use BitBag\SyliusWishlistPlugin\Context\WishlistContextInterface;
 use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
 use BitBag\SyliusWishlistPlugin\Form\Type\WishlistCollectionType;
 use BitBag\SyliusWishlistPlugin\Processor\WishlistCommandProcessorInterface;
-use BitBag\SyliusWishlistPlugin\Resolver\WishlistsResolverInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Context\CartNotFoundException;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -23,36 +23,19 @@ use Twig\Environment;
 
 final class ListWishlistProductsAction
 {
-    private CartContextInterface $cartContext;
-
-    private FormFactoryInterface $formFactory;
-
-    private Environment $twigEnvironment;
-
-    private WishlistCommandProcessorInterface $wishlistCommandProcessor;
-
-    private WishlistsResolverInterface $wishlistsResolver;
-
     public function __construct(
-        CartContextInterface $cartContext,
-        FormFactoryInterface $formFactory,
-        Environment $twigEnvironment,
-        WishlistCommandProcessorInterface $wishlistCommandProcessor,
-        WishlistsResolverInterface $wishlistsResolver
+        private CartContextInterface $cartContext,
+        private FormFactoryInterface $formFactory,
+        private Environment $twigEnvironment,
+        private WishlistCommandProcessorInterface $wishlistCommandProcessor,
+        private WishlistContextInterface $wishlistContext,
     ) {
-        $this->cartContext = $cartContext;
-        $this->formFactory = $formFactory;
-        $this->twigEnvironment = $twigEnvironment;
-        $this->wishlistCommandProcessor = $wishlistCommandProcessor;
-        $this->wishlistsResolver = $wishlistsResolver;
     }
 
     public function __invoke(Request $request): Response
     {
-        $wishlists = $this->wishlistsResolver->resolve();
-
         /** @var WishlistInterface $wishlist */
-        $wishlist = array_shift($wishlists);
+        $wishlist = $this->wishlistContext->getWishlist();
 
         try {
             $cart = $this->cartContext->getCart();

--- a/src/Controller/Action/RemoveProductFromWishlistAction.php
+++ b/src/Controller/Action/RemoveProductFromWishlistAction.php
@@ -64,7 +64,7 @@ final class RemoveProductFromWishlistAction
         }
 
         /** @var WishlistInterface $wishlist */
-        $wishlist = $this->wishlistContext->getWishlist($request);
+        $wishlist = $this->wishlistContext->getWishlist();
 
         foreach ($wishlist->getWishlistProducts() as $wishlistProduct) {
             if ($product === $wishlistProduct->getProduct()) {

--- a/src/DependencyInjection/BitBagSyliusWishlistExtension.php
+++ b/src/DependencyInjection/BitBagSyliusWishlistExtension.php
@@ -29,6 +29,7 @@ final class BitBagSyliusWishlistExtension extends AbstractResourceExtension impl
         $loader->load('services.yml');
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token', $config['wishlist_cookie_token']);
         $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.allowed_mime_types', $config['allowed_mime_types']);
+        $container->setParameter('bitbag_sylius_wishlist_plugin.parameters.wishlist_expiration_period', $config['wishlist_expiration_period']);
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/Event/SyliusEvent.php
+++ b/src/Event/SyliusEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Event;
+
+interface SyliusEvent
+{
+    public const REGISTER = 'sylius.customer.post_register';
+}

--- a/src/Event/WishlistSession.php
+++ b/src/Event/WishlistSession.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Event;
+
+interface WishlistSession
+{
+    public const CLEAR_COOKIE_ON_KERNEL_RESPONSE = 'clear-wishlist-cookie';
+}

--- a/src/EventSubscriber/BindUserToAnonymousWishlistEventSubscriber.php
+++ b/src/EventSubscriber/BindUserToAnonymousWishlistEventSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\EventSubscriber;
+
+use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
+use BitBag\SyliusWishlistPlugin\Event\SyliusEvent;
+use BitBag\SyliusWishlistPlugin\Event\WishlistSession;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+final class BindUserToAnonymousWishlistEventSubscriber implements EventSubscriberInterface
+{
+    private const AFTER_MERGE_WISHLIST_LISTENER_PRIORITY = 0;
+
+    public function __construct(
+        private string $cookieWishlistTokenName,
+        private SessionInterface $session,
+        private Security $security,
+        private RequestStack $requestStack,
+        private WishlistRepositoryInterface $wishlistRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SyliusEvent::REGISTER => [['onRegisterOrLogin', self::AFTER_MERGE_WISHLIST_LISTENER_PRIORITY]],
+            SecurityEvents::INTERACTIVE_LOGIN => [['onRegisterOrLogin', self::AFTER_MERGE_WISHLIST_LISTENER_PRIORITY]],
+        ];
+    }
+
+    public function onRegisterOrLogin(): void
+    {
+        $user = $this->security->getUser();
+
+        $cookies = $this->requestStack->getMainRequest()->cookies;
+
+        if (!$user instanceof ShopUserInterface || !$cookies->has($this->cookieWishlistTokenName) || $this->session->has(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE)) {
+            return;
+        }
+
+        $cookieWishlist = $this->wishlistRepository->findByToken($cookies->get($this->cookieWishlistTokenName));
+
+        if (!$cookieWishlist instanceof WishlistInterface) {
+            return;
+        }
+
+        $cookieWishlist->setShopUser($user);
+
+        $this->wishlistRepository->save($cookieWishlist);
+
+        $this->session->set(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE, true);
+    }
+}

--- a/src/EventSubscriber/MergeWishlistsEventSubscriber.php
+++ b/src/EventSubscriber/MergeWishlistsEventSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\EventSubscriber;
+
+use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
+use BitBag\SyliusWishlistPlugin\Event\SyliusEvent;
+use BitBag\SyliusWishlistPlugin\Event\WishlistSession;
+use BitBag\SyliusWishlistPlugin\Helper\WishlistsMerger;
+use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+final class MergeWishlistsEventSubscriber implements EventSubscriberInterface
+{
+    private const BEFORE_BIND_USER_LISTENER_PRIORITY = 1;
+
+    public function __construct(
+        private string $cookieWishlistTokenName,
+        private SessionInterface $session,
+        private Security $security,
+        private RequestStack $requestStack,
+        private WishlistRepositoryInterface $wishlistRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SyliusEvent::REGISTER => [['onRegisterOrLogin', self::BEFORE_BIND_USER_LISTENER_PRIORITY]],
+            SecurityEvents::INTERACTIVE_LOGIN => [['onRegisterOrLogin', self::BEFORE_BIND_USER_LISTENER_PRIORITY]],
+        ];
+    }
+
+    public function onRegisterOrLogin(): void
+    {
+        $user = $this->security->getUser();
+
+        $cookies = $this->requestStack->getMainRequest()->cookies;
+
+        if (!$user instanceof ShopUserInterface || !$cookies->has($this->cookieWishlistTokenName) || $this->session->has(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE)) {
+            return;
+        }
+
+        $cookieWishlist = $this->wishlistRepository->findByToken($cookies->get($this->cookieWishlistTokenName));
+
+        if (!$cookieWishlist instanceof WishlistInterface) {
+            return;
+        }
+
+        $userWishlist = $this->wishlistRepository->findOneByShopUser($user);
+
+        if (!$userWishlist instanceof WishlistInterface) {
+            return;
+        }
+
+        $userWishlist = WishlistsMerger::mergeProducts($cookieWishlist, $userWishlist);
+
+        $this->wishlistRepository->save($userWishlist);
+        $this->wishlistRepository->delete($cookieWishlist);
+
+        $this->session->set(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE, true);
+    }
+}

--- a/src/EventSubscriber/RemoveWishlistCookieEventSubscriber.php
+++ b/src/EventSubscriber/RemoveWishlistCookieEventSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\EventSubscriber;
+
+use BitBag\SyliusWishlistPlugin\Event\WishlistSession;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class RemoveWishlistCookieEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private string $cookieWishlistTokenName,
+        private SessionInterface $session,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $cookies = $this->requestStack->getMainRequest()->cookies;
+
+        if (!$cookies->has($this->cookieWishlistTokenName) || !$this->session->has(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE)) {
+            return;
+        }
+
+        $this->session->remove(WishlistSession::CLEAR_COOKIE_ON_KERNEL_RESPONSE);
+
+        $event->getResponse()->headers->clearCookie($this->cookieWishlistTokenName);
+    }
+}

--- a/src/Form/Extension/AddToCartTypeExtension.php
+++ b/src/Form/Extension/AddToCartTypeExtension.php
@@ -38,12 +38,6 @@ final class AddToCartTypeExtension extends AbstractTypeExtension
                         'class' => 'bitbag-add-variant-to-wishlist ui icon labeled button',
                     ],
                 ])
-                ->add('wishlists', EntityType::class, [
-                    'class' => Wishlist::class,
-                    'choices' => $this->wishlistsResolver->resolve(),
-                    'choice_label' => 'name',
-                    'mapped' => false,
-                ])
             ;
         }
     }

--- a/src/Helper/WishlistsMerger.php
+++ b/src/Helper/WishlistsMerger.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Helper;
+
+use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
+use BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface;
+
+final class WishlistsMerger
+{
+    public static function mergeProducts(WishlistInterface $fromWishlist, WishlistInterface $intoWishlist): WishlistInterface
+    {
+        /** @var WishlistProductInterface $cookieWishlistProduct */
+        foreach ($fromWishlist->getWishlistProducts() as $cookieWishlistProduct) {
+            if ($intoWishlist->getProducts()->contains($cookieWishlistProduct->getProduct())) {
+                continue;
+            }
+
+            $intoWishlist->addWishlistProduct(clone $cookieWishlistProduct);
+        }
+
+        return $intoWishlist;
+    }
+}

--- a/src/Migrations/Version20221206172354.php
+++ b/src/Migrations/Version20221206172354.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusWishlistPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221206172354 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add wishlist updated_at & created_at field to track old ones';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD created_at DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE bitbag_wishlist ADD updated_at DATETIME DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP created_at');
+        $this->addSql('ALTER TABLE bitbag_wishlist DROP updated_at');
+    }
+}

--- a/src/Repository/WishlistRepository.php
+++ b/src/Repository/WishlistRepository.php
@@ -153,4 +153,16 @@ final class WishlistRepository extends EntityRepository implements WishlistRepos
             ->getResult()
         ;
     }
+
+    public function save(WishlistInterface $wishlist): void
+    {
+        $this->getEntityManager()->persist($wishlist);
+        $this->getEntityManager()->flush();
+    }
+
+    public function delete(WishlistInterface $wishlist): void
+    {
+        $this->getEntityManager()->remove($wishlist);
+        $this->getEntityManager()->flush();
+    }
 }

--- a/src/Repository/WishlistRepositoryInterface.php
+++ b/src/Repository/WishlistRepositoryInterface.php
@@ -41,4 +41,8 @@ interface WishlistRepositoryInterface extends RepositoryInterface
     public function findOneByShopUserAndName(ShopUserInterface $shopUser, string $name): ?WishlistInterface;
 
     public function deleteWishlistsNotModifiedSince(\DateTimeInterface $period): void;
+
+    public function save(WishlistInterface $wishlist): void;
+
+    public function delete(WishlistInterface $wishlist): void;
 }

--- a/src/Resolver/WishlistsResolver.php
+++ b/src/Resolver/WishlistsResolver.php
@@ -10,54 +10,18 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusWishlistPlugin\Resolver;
 
-use BitBag\SyliusWishlistPlugin\Repository\WishlistRepositoryInterface;
-use Sylius\Component\Channel\Context\ChannelContextInterface;
-use Sylius\Component\Channel\Context\ChannelNotFoundException;
-use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\ShopUserInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use BitBag\SyliusWishlistPlugin\Context\WishlistContextInterface;
 
 final class WishlistsResolver implements WishlistsResolverInterface
 {
-    private WishlistRepositoryInterface $wishlistRepository;
-
-    private TokenStorageInterface $tokenStorage;
-
-    private WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver;
-
-    private ChannelContextInterface $channelContext;
-
-    public function __construct(
-        WishlistRepositoryInterface $wishlistRepository,
-        TokenStorageInterface $tokenStorage,
-        WishlistCookieTokenResolverInterface $wishlistCookieTokenResolver,
-        ChannelContextInterface $channelContext
-    ) {
-        $this->wishlistRepository = $wishlistRepository;
-        $this->tokenStorage = $tokenStorage;
-        $this->wishlistCookieTokenResolver = $wishlistCookieTokenResolver;
-        $this->channelContext = $channelContext;
+    public function __construct(private WishlistContextInterface $wishlistContext)
+    {
     }
 
     public function resolve(): array
     {
-        $user = $this->tokenStorage->getToken() ? $this->tokenStorage->getToken()->getUser() : null;
-        $wishlistCookieToken = $this->wishlistCookieTokenResolver->resolve();
-
-        try {
-            $channel = $this->channelContext->getChannel();
-        } catch (ChannelNotFoundException $foundException) {
-            $channel = null;
-        }
-
-        if ($user instanceof ShopUserInterface) {
-            return $this->wishlistRepository->findAllByShopUserAndToken($user->getId(), $wishlistCookieToken);
-        }
-
-        if ($channel instanceof ChannelInterface) {
-            return $this->wishlistRepository->findAllByAnonymousAndChannel($wishlistCookieToken, $channel);
-        }
-
-        return $this->wishlistRepository->findAllByAnonymous($wishlistCookieToken);
+        return [
+            $this->wishlistContext->getWishlist(),
+        ];
     }
 }

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -46,7 +46,7 @@ bitbag_sylius_wishlist_plugin_shop_wishlist_import_from_csv:
         _controller: bitbag_sylius_wishlist_plugin.controller.action.import_from_csv
 
 bitbag_sylius_wishlist_plugin_shop_wishlist_remove_product_variant:
-    path: /wishlist/{wishlistId}/remove/variant/{variantId}
+    path: /wishlist/remove/variant/{variantId}
     defaults:
         _controller: bitbag_sylius_wishlist_plugin.controller.action.remove_product_variant_from_wishlist
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -41,7 +41,7 @@ services:
             - "@bitbag_sylius_wishlist_plugin.factory.wishlist_product"
             - '@request_stack'
             - "@translator"
-            - "@bitbag_sylius_wishlist_plugin.resolver.wishlists_resolver"
+            - "@bitbag_sylius_wishlist_plugin.context.wishlist"
             - "@bitbag_sylius_wishlist_plugin.manager.wishlist"
             - "@sylius.context.channel"
             - "@bitbag_sylius_wishlist_plugin.factory.wishlist"
@@ -89,12 +89,12 @@ services:
     bitbag_sylius_wishlist_plugin.controller.action.remove_product_variant_from_wishlist:
         class: BitBag\SyliusWishlistPlugin\Controller\Action\RemoveProductVariantFromWishlistAction
         arguments:
-            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
             - "@sylius.repository.product_variant"
             - "@bitbag_sylius_wishlist_plugin.manager.wishlist_product"
             - '@request_stack'
             - "@translator"
             - "@router"
+            - "@bitbag_sylius_wishlist_plugin.context.wishlist"
         tags:
             - { name: controller.service_arguments }
 
@@ -146,7 +146,7 @@ services:
             - "@form.factory"
             - "@twig"
             - "@bitbag_sylius_wishlist_plugin.processor.wishlist_command_processor"
-            - "@bitbag_sylius_wishlist_plugin.resolver.wishlists_resolver"
+            - "@bitbag_sylius_wishlist_plugin.context.wishlist"
         tags:
             - { name: controller.service_arguments }
 
@@ -161,11 +161,10 @@ services:
         class: BitBag\SyliusWishlistPlugin\Context\WishlistContext
         public: true
         arguments:
-            - "@security.token_storage"
-            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
-            - "@bitbag_sylius_wishlist_plugin.factory.wishlist"
             - "%bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token%"
-            - "@sylius.context.channel"
+            - "@security.helper"
+            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
+            - "@request_stack"
 
     bitbag_sylius_wishlist_plugin.custom_factory.wishlist:
         class: BitBag\SyliusWishlistPlugin\Factory\WishlistFactory
@@ -365,9 +364,9 @@ services:
             - { name: controller.service_arguments }
 
     bitbag_sylius_wishlist_plugin.command.remove_expired_wishlists:
-        class: BitBag\SyliusWishlistPlugin\Command\RemoveExpiredWishlistsCommand
+        class: BitBag\SyliusWishlistPlugin\Command\Wishlist\RemoveExpiredWishlistsCommand
         arguments:
-            - '@bitbag_sylius_wishlist_plugin.repository.wishlist'
-            - '%bitbag_sylius_wishlist_plugin.parameters.wishlist_expiration_period%'
+            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
+            - "%bitbag_sylius_wishlist_plugin.parameters.wishlist_expiration_period%"
         tags:
             - { name: console.command }

--- a/src/Resources/config/services/event_subscriber.yml
+++ b/src/Resources/config/services/event_subscriber.yml
@@ -1,0 +1,31 @@
+services:
+    bitbag_sylius_wishlist_plugin.event_subscriber.bind_user_to_anonymous_wishlist:
+        class: BitBag\SyliusWishlistPlugin\EventSubscriber\BindUserToAnonymousWishlistEventSubscriber
+        arguments:
+            - "%bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token%"
+            - '@session'
+            - "@security.helper"
+            - '@request_stack'
+            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
+        tags:
+            - { name: kernel.event_subscriber }
+
+    bitbag_sylius_wishlist_plugin.event_subscriber.merge_wishlists:
+        class: BitBag\SyliusWishlistPlugin\EventSubscriber\MergeWishlistsEventSubscriber
+        arguments:
+            - "%bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token%"
+            - '@session'
+            - "@security.helper"
+            - '@request_stack'
+            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
+        tags:
+            - { name: kernel.event_subscriber }
+
+    bitbag_sylius_wishlist_plugin.event_subscriber.remove_wishlist_cookie:
+        class: BitBag\SyliusWishlistPlugin\EventSubscriber\RemoveWishlistCookieEventSubscriber
+        arguments:
+            - "%bitbag_sylius_wishlist_plugin.parameters.wishlist_cookie_token%"
+            - '@session'
+            - '@request_stack'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Resources/config/services/resolver.yml
+++ b/src/Resources/config/services/resolver.yml
@@ -9,10 +9,7 @@ services:
     bitbag_sylius_wishlist_plugin.resolver.wishlists_resolver:
         class: BitBag\SyliusWishlistPlugin\Resolver\WishlistsResolver
         arguments:
-            - "@bitbag_sylius_wishlist_plugin.repository.wishlist"
-            - "@security.token_storage"
-            - "@bitbag_sylius_wishlist_plugin.resolver.wishlist_cookie_token_resolver"
-            - "@sylius.context.channel"
+            - "@bitbag_sylius_wishlist_plugin.context.wishlist"
 
     bitbag_sylius_wishlist_plugin.resolver.wishlist_cookie_token_resolver:
         class: BitBag\SyliusWishlistPlugin\Resolver\WishlistCookieTokenResolver


### PR DESCRIPTION
New behavior
--------------

- there's only one wishlist now
- wishlist retrieving through context only
- merge wishlist (if needed) on user login + register
- bind user to anonymous wishlist (if needed) on user login + register
- remove cookie (if needed)

<img width="1688" alt="image" src="https://user-images.githubusercontent.com/1702264/210758840-322f24e2-468a-4a38-865b-ddc7e9fd4a2f.png">

Other
-----
- fix missing service declaration
- add missing migration
