### PR TITLE
:bug: fix selection of variant

### DIFF
--- a/src/Factory/WishlistProductFactory.php
+++ b/src/Factory/WishlistProductFactory.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusWishlistPlugin\Factory;
 
+use App\Entity\Product\ProductVariant;
 use BitBag\SyliusWishlistPlugin\Entity\WishlistInterface;
 use BitBag\SyliusWishlistPlugin\Entity\WishlistProductInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -42,7 +43,7 @@ final class WishlistProductFactory implements WishlistProductFactoryInterface
         $wishlistProduct->setWishlist($wishlist);
         $wishlistProduct->setProduct($product);
         /** @var ProductVariantInterface $variant */
-        $variant = $product->getVariants()->first();
+        $variant = $product->getVariants()->filter(fn(ProductVariant $variant) => $variant->isEnabled())->first();
         $wishlistProduct->setVariant($variant);
 
         return $wishlistProduct;


### PR DESCRIPTION
It's possible to add a product to the wishlist without specifying a variant. In this case, the first variant was taken beside it may actually be disabled. I added a filter on enabled variants.